### PR TITLE
Virtual viewport rendering, transform-based zoom, and timing fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 .aider*
+
+# Integration test ephemeral output (screenshots and AI reports)
+test/integration/output/
+test/integration/reports/
+
+# Playwright cache
+node_modules/

--- a/index.html
+++ b/index.html
@@ -102,13 +102,18 @@
 					</a>
 
 				<span style="width: 50px;"></span>
+				Size:
+				<button onclick="setFontSize(getFontSize() - 4); rerender()">-</button>
+				<button onclick="setFontSize(getFontSize() + 4); rerender()">+</button>
+
+				<span style="width: 20px;"></span>
 				Zoom:
-				<button onclick="setFontSize(getFontSize() + 4); rerender()">
-					+
-				</button>
-				<button onclick="setFontSize(getFontSize() - 4); rerender()">
-					-
-				</button>
+				<input type="range" id="zoom_slider"
+					min="0.25" max="4.0" step="0.01" value="1.0"
+					oninput="applyZoom(parseFloat(this.value))"
+					style="width: 100px; vertical-align: middle;"
+				/>
+				<span id="zoom_label" style="min-width: 40px; display: inline-block; text-align: center;">100%</span>
 
 				<span style="width: 20px;"></span>
 				Parser:
@@ -204,6 +209,43 @@
 
 				// console.log('drag', e)
 			}
+
+			// ---- Zoom handler (transform-based, no re-layout) ----
+
+			function applyZoom(newLevel) {
+				var oldZoom = getZoomLevel()
+
+				setZoomLevel(newLevel)
+				var zoom = getZoomLevel() // read back clamped value
+
+				// Update slider and label to match the (clamped) value
+				var slider = document.getElementById('zoom_slider')
+				var label  = document.getElementById('zoom_label')
+				if (slider) slider.value = zoom
+				if (label)  label.textContent = Math.round(zoom * 100) + '%'
+
+				// Center-preserving scroll: keep the same score-space point at
+				// the viewport center before and after zoom.
+				// centerScore = (scrollLeft + clientWidth/2) / oldZoom
+				// newScrollLeft = centerScore * newZoom - clientWidth/2
+				var cx = (scoreElm.scrollLeft + scoreElm.clientWidth  / 2) / oldZoom
+				var cy = (scoreElm.scrollTop  + scoreElm.clientHeight / 2) / oldZoom
+
+				// Resize the invisible_canvas spacer so scroll bounds are correct
+				// before we set the new scroll position.
+				var ic = document.getElementById('invisible_canvas')
+				if (ic && typeof maxCanvasWidth !== 'undefined') {
+					ic.style.width  = (maxCanvasWidth  * zoom) + 'px'
+					ic.style.height = Math.max(maxCanvasHeight * zoom, scoreElm.clientHeight) + 'px'
+				}
+
+				scoreElm.scrollLeft = cx * zoom - scoreElm.clientWidth  / 2
+				scoreElm.scrollTop  = cy * zoom - scoreElm.clientHeight / 2
+
+				quickDraw(null, -scoreElm.scrollLeft, -scoreElm.scrollTop)
+			}
+
+			window.applyZoom = applyZoom
 		</script>
 	</body>
 </html>

--- a/lib/nwc2xml/objects.js
+++ b/lib/nwc2xml/objects.js
@@ -195,6 +195,7 @@ export class RestObj extends NWCObj {
     let dt = 0;
     if (this.data2[3] & 0x01) dt |= DurationType.DotDot;
     else if (this.data2[3] & 0x04) dt |= DurationType.Dot;
+    if (this.data2[1] & 0x0C) dt |= (this.data2[1] & 0x0C);
     return dt;
   }
   getDurationTicks(div) {
@@ -202,12 +203,14 @@ export class RestObj extends NWCObj {
     const dt = this.getDurationType();
     if (dt & DurationType.DotDot) d += d / 4;
     else if (dt & DurationType.Dot) d += d / 2;
+    if (dt & DurationType.Triplet) d = d * 2 / 3;
     return Math.round(d * 4);
   }
   getDivision() {
     let d = 1 << this.getDuration();
     if (this.data2[3] & 0x01) d <<= 2;
     else if (this.data2[3] & 0x04) d <<= 1;
+    if (this.data2[1] & 0x0C) d = (d % 2) ? d * 3 : (d / 2) * 3;
     return d;
   }
   getOctaveStep(clefShift) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,14 @@
     "nwc2xml": "./bin/nwc2xml.js"
   },
   "scripts": {
-    "test": "bun test"
+    "test": "bun test test/*.test.js",
+    "test:integration": "playwright test",
+    "test:integration:update": "UPDATE_SNAPSHOTS=1 playwright test --update-snapshots",
+    "test:score": "bun test/integration/scorer.js",
+    "test:all": "playwright test && bun test/integration/scorer.js"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.58.2"
   },
   "author": "Joshua Koo",
   "bugs": {

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,11 +5,30 @@ let FONT_SIZE = 60 // 42
 // 1-1.25 key 1-1.5 timesig 2 note p.42
 
 function setFontSize(n) {
-	FONT_SIZE = n
+	// Clamp to a safe range: below ~12 px, glyphs become unreadable and line
+	// widths degenerate; 0 or negative causes division-by-zero / infinite loops.
+	// Above ~240 px, a single staff barely fits a screen — further zoom is
+	// unlikely to be useful.
+	FONT_SIZE = Math.max(12, Math.min(240, n))
 }
 
 function getFontSize() {
 	return FONT_SIZE
+}
+
+// Visual zoom level — applied as a canvas transform in quickDraw().
+// This does NOT trigger a re-layout; it simply scales the rendered output.
+// Use setFontSize() to change the actual music engraving size (requires re-layout).
+let zoomLevel = 1.0
+const ZOOM_MIN = 0.25
+const ZOOM_MAX = 4.0
+
+function setZoomLevel(n) {
+	zoomLevel = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, n))
+}
+
+function getZoomLevel() {
+	return zoomLevel
 }
 
 function isNode() {
@@ -26,6 +45,14 @@ Object.assign(!isBrowser() ? global : window, {
 	FONT_SIZE,
 	setFontSize,
 	getFontSize,
+	setZoomLevel,
+	getZoomLevel,
+	ZOOM_MIN,
+	ZOOM_MAX,
 })
 
-export { isNode, isBrowser, FONT_SIZE, setFontSize, getFontSize }
+export {
+	isNode, isBrowser,
+	FONT_SIZE, setFontSize, getFontSize,
+	setZoomLevel, getZoomLevel, ZOOM_MIN, ZOOM_MAX,
+}

--- a/src/drawing.js
+++ b/src/drawing.js
@@ -120,8 +120,8 @@ function resize(width, height) {
 
 	canvas.width = width * dpr
 	canvas.height = height * dpr
-	canvas.style.width = width
-	canvas.style.height = height
+	canvas.style.width = width + 'px'
+	canvas.style.height = height + 'px'
 
 	ctx.scale(dpr, dpr)
 }

--- a/src/drawing.js
+++ b/src/drawing.js
@@ -1,6 +1,6 @@
 import './constants.js'
 import { ajax } from './loaders.js'
-import { getFontSize } from './constants.js'
+import { getFontSize, getZoomLevel } from './constants.js'
 
 const fontMap = {
 	// barlines
@@ -610,13 +610,20 @@ class Drawing {
 	static _draw(ctx, el, viewportWidth, viewportOffsetX, viewportHeight, viewportOffsetY) {
 		if (el instanceof Draw) {
 			// Viewport culling — skip elements entirely outside the visible area.
+			// The margin scales with font size so that large zoom levels don't
+			// clip oversized glyphs / staves.  Most elements never set `height`,
+			// so we fall back to 4× font size (covers a full staff + ledger lines).
+			var margin = getFontSize() * 4
+			var elW = el.width || margin
+			var elH = el.height || margin
+
 			// Horizontal
-			if (el.x > viewportOffsetX + viewportWidth + 200) return
-			if (el.x + (el.width || 0) < viewportOffsetX - 200) return
+			if (el.x > viewportOffsetX + viewportWidth + margin) return
+			if (el.x + elW < viewportOffsetX - margin) return
 			// Vertical
 			var elY = el.y + (el.offsetY || 0)
-			if (elY > viewportOffsetY + viewportHeight + 200) return
-			if (elY + (el.height || 0) < viewportOffsetY - 200) return
+			if (elY > viewportOffsetY + viewportHeight + margin) return
+			if (elY + elH < viewportOffsetY - margin) return
 
 			ctx.save()
 			ctx.translate(el.x, el.y)
@@ -638,10 +645,14 @@ class Drawing {
 	}
 
 	draw(ctx) {
-		const viewportWidth = scoreElm.clientWidth
-		const viewportOffsetX = scoreElm.scrollLeft
-		const viewportHeight = scoreElm.clientHeight
-		const viewportOffsetY = scoreElm.scrollTop
+		// Convert screen-space viewport bounds to score-space for culling.
+		// quickDraw() applies ctx.scale(zoom) so drawing coordinates are in
+		// score-space, but scrollLeft/clientWidth are in screen pixels.
+		const zoom = getZoomLevel()
+		const viewportWidth = scoreElm.clientWidth / zoom
+		const viewportOffsetX = scoreElm.scrollLeft / zoom
+		const viewportHeight = scoreElm.clientHeight / zoom
+		const viewportOffsetY = scoreElm.scrollTop / zoom
 
 		// Restore default font/baseline — canvas resets wipe context state
 		// (e.g. after resizeToFit()), so re-apply on every draw pass.

--- a/src/drawing.js
+++ b/src/drawing.js
@@ -113,13 +113,22 @@ function resizeToFit() {
 }
 
 function resize(width, height) {
-	var dpr = window.devicePixelRatio
+	// Browsers cap canvas backing-store dimensions (typically 16 384 px per axis).
+	// Reduce the effective DPR when the logical size would exceed the limit so the
+	// canvas is created at lower resolution rather than throwing.
+	var MAX_CANVAS_DIM = 16384
+	var nativeDpr = window.devicePixelRatio || 1
 
 	width = width || 800
 	height = height || 800
 
-	canvas.width = width * dpr
-	canvas.height = height * dpr
+	var dpr = Math.min(
+		nativeDpr,
+		MAX_CANVAS_DIM / width,
+		MAX_CANVAS_DIM / height
+	)
+	canvas.width = Math.round(width * dpr)
+	canvas.height = Math.round(height * dpr)
 	canvas.style.width = width + 'px'
 	canvas.style.height = height + 'px'
 
@@ -598,11 +607,16 @@ class Drawing {
 		this.set.delete(el)
 	}
 
-	static _draw(ctx, el, viewportWidth, viewportOffsetX) {
+	static _draw(ctx, el, viewportWidth, viewportOffsetX, viewportHeight, viewportOffsetY) {
 		if (el instanceof Draw) {
-			// TODO run quick check aabb bounds here to reduce rendering costs
+			// Viewport culling — skip elements entirely outside the visible area.
+			// Horizontal
 			if (el.x > viewportOffsetX + viewportWidth + 200) return
-			if (el.x + el.w < viewportOffsetX - 200) return
+			if (el.x + (el.width || 0) < viewportOffsetX - 200) return
+			// Vertical
+			var elY = el.y + (el.offsetY || 0)
+			if (elY > viewportOffsetY + viewportHeight + 200) return
+			if (elY + (el.height || 0) < viewportOffsetY - 200) return
 
 			ctx.save()
 			ctx.translate(el.x, el.y)
@@ -626,10 +640,18 @@ class Drawing {
 	draw(ctx) {
 		const viewportWidth = scoreElm.clientWidth
 		const viewportOffsetX = scoreElm.scrollLeft
+		const viewportHeight = scoreElm.clientHeight
+		const viewportOffsetY = scoreElm.scrollTop
+
+		// Restore default font/baseline — canvas resets wipe context state
+		// (e.g. after resizeToFit()), so re-apply on every draw pass.
+		ctx.font = `${getFontSize()}px Arial, 'Segoe UI', sans-serif`
+		ctx.textBaseline = 'alphabetic'
+		ctx.fillStyle = '#000'
 
 		ctx.save()
 		for (const el of this.set) {
-			Drawing._draw(ctx, el, viewportWidth, viewportOffsetX)
+			Drawing._draw(ctx, el, viewportWidth, viewportOffsetX, viewportHeight, viewportOffsetY)
 		}
 		ctx.restore()
 	}

--- a/src/editing.js
+++ b/src/editing.js
@@ -51,6 +51,12 @@ class ScoreManager {
 	}
 
 	setData(score) {
+		if (!score || !score.score || !Array.isArray(score.score.staves)) {
+			throw new Error(
+				'Invalid score data: expected { score: { staves: [] } }, got ' +
+				JSON.stringify(score && score.score ? Object.keys(score.score) : score)
+			)
+		}
 		this.score = score
 
 		var staves = this.getStaves()

--- a/src/fraction.js
+++ b/src/fraction.js
@@ -15,6 +15,12 @@ class Fraction {
 			throw new Error('BadArgument', `Invalid numbers: ${a}, ${b}`)
 		}
 
+		// Guard against NaN or Infinity which would cause an infinite loop in
+		// the Euclidean algorithm (NaN !== 0 is always true).
+		if (!isFinite(a) || !isFinite(b) || isNaN(a) || isNaN(b)) {
+			return 1
+		}
+
 		let t
 
 		while (b !== 0) {

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -379,11 +379,13 @@ SightReader.prototype._handle_duration = function (token) {
 		dur = 4
 	}
 	token.durValue = new Fraction(1, dur)
-	for (var i = 0; i < token.dots; i++) {
+	// Dotted: d * 3/2.  Double-dotted: d * 7/4 (NOT 3/2 * 3/2 = 9/4).
+	if (token.dots === 2) {
+		token.durValue.multiply(7, 4)
+	} else if (token.dots === 1) {
 		token.durValue.multiply(3, 2)
 	}
 	if (token.triplet) {
-		// FIXME
 		token.durValue.multiply(2, 3)
 	}
 }

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -370,7 +370,15 @@ SightReader.prototype.Note = function (token) {
 }
 
 SightReader.prototype._handle_duration = function (token) {
-	token.durValue = new Fraction(1, token.duration)
+	// Guard against missing or zero duration: fall back to quarter note (4).
+	// A zero denominator in Fraction(1, 0) propagates NaN through simplify()
+	// and then triggers an infinite loop in GCD(NaN, NaN).
+	var dur = token.duration
+	if (!dur || !isFinite(dur) || dur <= 0) {
+		console.warn('_handle_duration: invalid duration', dur, 'on token', token.type, '- defaulting to 4')
+		dur = 4
+	}
+	token.durValue = new Fraction(1, dur)
 	for (var i = 0; i < token.dots; i++) {
 		token.durValue.multiply(3, 2)
 	}

--- a/src/layout/typeset.js
+++ b/src/layout/typeset.js
@@ -1,6 +1,7 @@
 import { getFontSize } from '../constants.js'
 import { layoutBeaming } from './beams.js'
 import { layoutTies } from './ties.js'
+import { resizeToFit } from '../drawing.js'
 
 // based on nwc music json representation,
 // attempt to convert them to symbols to be drawn.
@@ -266,15 +267,16 @@ function score(dataOrContext) {
 	}
 	footer.innerText = copyright1 + '\n' + copyright2
 
-	// Always resize canvas to exactly fit the computed score dimensions.
-	// This prevents right-edge and bottom-edge clipping regardless of viewport size.
+	// Virtual rendering: keep the canvas at viewport size and let the
+	// invisible_canvas spacer provide the scrollable area.  On each scroll
+	// frame quickDraw() re-renders only the visible portion via
+	// ctx.translate() + viewport culling in Drawing._draw().
+	//
+	// resizeToFit() sizes the canvas to the #score container's visible area
+	// (which is already the case on first load).  This avoids ever creating a
+	// canvas anywhere near browser backing-store limits.
 	if (canvas) {
-		const dpr = window.devicePixelRatio || 1
-		canvas.width = maxCanvasWidth * dpr
-		canvas.height = maxCanvasHeight * dpr
-		canvas.style.width = maxCanvasWidth + 'px'
-		canvas.style.height = maxCanvasHeight + 'px'
-		ctx.scale(dpr, dpr)
+		resizeToFit()
 	}
 	/*
 
@@ -297,7 +299,10 @@ function score(dataOrContext) {
 	}
 	*/
 
-	drawing.draw(ctx)
+	// Draw the visible portion of the score, offset by the current scroll
+	// position.  This is the same path the scroll handler takes on every frame.
+	var scoreElm = document.getElementById('score')
+	quickDraw(null, -(scoreElm?.scrollLeft || 0), -(scoreElm?.scrollTop || 0))
 
 	// TODO move this out of this function
 

--- a/src/layout/typeset.js
+++ b/src/layout/typeset.js
@@ -1,4 +1,4 @@
-import { getFontSize } from '../constants.js'
+import { getFontSize, getZoomLevel } from '../constants.js'
 import { layoutBeaming } from './beams.js'
 import { layoutTies } from './ties.js'
 import { resizeToFit } from '../drawing.js'
@@ -139,7 +139,11 @@ function quickDraw(dataOrContext, x, y) {
 	
 	ctx.clearRect(0, 0, canvas.width, canvas.height)
 	ctx.save()
+	// Translate by screen-space scroll offset, then scale into score-space.
+	// The transform chain is: DPR (from resize) → scroll translate → zoom scale.
 	ctx.translate(x || 0, y || 0)
+	var zoom = getZoomLevel()
+	if (zoom !== 1) ctx.scale(zoom, zoom)
 	drawing.draw(ctx)
 	ctx.restore()
 }
@@ -267,53 +271,30 @@ function score(dataOrContext) {
 	}
 	footer.innerText = copyright1 + '\n' + copyright2
 
+	// Size the invisible_canvas spacer BEFORE rendering so the browser can
+	// clamp scrollLeft / scrollTop to the new content bounds (e.g. after zoom
+	// changes the score dimensions).  The spacer dimensions are in screen-space
+	// (score-space × zoom) so the scrollbar range matches the zoomed extent.
+	var invisible_canvas = document.getElementById('invisible_canvas')
+	var scoreElm = document.getElementById('score')
+	var zoom = getZoomLevel()
+	invisible_canvas.style.width = `${maxCanvasWidth * zoom}px`
+	invisible_canvas.style.height = `${Math.max(
+		maxCanvasHeight * zoom,
+		scoreElm.clientHeight
+	)}px`
+
 	// Virtual rendering: keep the canvas at viewport size and let the
 	// invisible_canvas spacer provide the scrollable area.  On each scroll
 	// frame quickDraw() re-renders only the visible portion via
 	// ctx.translate() + viewport culling in Drawing._draw().
-	//
-	// resizeToFit() sizes the canvas to the #score container's visible area
-	// (which is already the case on first load).  This avoids ever creating a
-	// canvas anywhere near browser backing-store limits.
 	if (canvas) {
 		resizeToFit()
 	}
-	/*
-
-	if (copyright1) {
-		const authorDrawing = new Claire.Text(copyright1, 0, {
-			font: '10px arial',
-			textAlign: 'center',
-		}) // italic bold
-		authorDrawing.moveTo(middle, bottom + 80)
-		drawing.add(authorDrawing)
-	}
-
-	if (copyright2) {
-		const authorDrawing = new Claire.Text(copyright2, 0, {
-			font: '10px arial',
-			textAlign: 'center',
-		}) // italic bold
-		authorDrawing.moveTo(middle, bottom + 90)
-		drawing.add(authorDrawing)
-	}
-	*/
 
 	// Draw the visible portion of the score, offset by the current scroll
-	// position.  This is the same path the scroll handler takes on every frame.
-	var scoreElm = document.getElementById('score')
+	// position (now correctly clamped by the spacer resize above).
 	quickDraw(null, -(scoreElm?.scrollLeft || 0), -(scoreElm?.scrollTop || 0))
-
-	// TODO move this out of this function
-
-	var invisible_canvas = document.getElementById('invisible_canvas')
-	invisible_canvas.style.width = `${maxCanvasWidth}px`
-	invisible_canvas.style.height = `${Math.max(
-		maxCanvasHeight,
-		document.getElementById('score').clientHeight
-	)}px`
-
-	// https://stackoverflow.com/questions/21064101/understanding-offsetwidth-clientwidth-scrollwidth-and-height-respectively
 }
 
 function getStaffY(staffIndex) {

--- a/src/layout/typeset.js
+++ b/src/layout/typeset.js
@@ -179,8 +179,18 @@ function score(dataOrContext) {
 
 	tickTracker.reset()
 
+	// Safety limit: total token count × 2 is a generous upper bound.
+	// An infinite spin means no cursor advanced; break and warn rather than hang.
+	const totalTokens = stavePointers.reduce((n, c) => n + c.tokens.length, 0)
+	let layoutIterations = 0
+	const maxIterations = Math.max(totalTokens * 2, 100)
+
 	while (true) {
-		// for (var i = 0; i < 50; i++) {
+		if (++layoutIterations > maxIterations) {
+			console.warn(`Layout loop exceeded ${maxIterations} iterations — aborting to prevent hang`)
+			break
+		}
+
 		if (!stavePointers.some((s) => s.hasNext())) {
 			console.log('nothing left')
 			break
@@ -204,6 +214,7 @@ function score(dataOrContext) {
 			stavePointers[smallestIndex].next(handleToken)
 		} else {
 			console.log('no candidate!!')
+			break
 		}
 	}
 
@@ -232,7 +243,10 @@ function score(dataOrContext) {
 	maxCanvasHeight = bottom + 100
 
 	var { title, author, copyright1, copyright2 } = data.info || {}
-	var middle = window.innerWidth / 2
+
+	// Use canvas width (set after resize) for centering — not window.innerWidth
+	// which can differ in headless/embedded contexts.
+	var middle = maxCanvasWidth / 2
 	if (title) {
 		const titleDrawing = new Claire.Text(title, 0, {
 			font: "bold 20px Arial, 'Segoe UI', sans-serif",
@@ -251,6 +265,17 @@ function score(dataOrContext) {
 		drawing.add(authorDrawing)
 	}
 	footer.innerText = copyright1 + '\n' + copyright2
+
+	// Always resize canvas to exactly fit the computed score dimensions.
+	// This prevents right-edge and bottom-edge clipping regardless of viewport size.
+	if (canvas) {
+		const dpr = window.devicePixelRatio || 1
+		canvas.width = maxCanvasWidth * dpr
+		canvas.height = maxCanvasHeight * dpr
+		canvas.style.width = maxCanvasWidth + 'px'
+		canvas.style.height = maxCanvasHeight + 'px'
+		ctx.scale(dpr, dpr)
+	}
 	/*
 
 	if (copyright1) {
@@ -345,15 +370,17 @@ function handleToken(token, tokenIndex, staveIndex, cursor) {
 
 				cursor.incStaveX(t.width * 2)
 			} else if (token.group && token.beat) {
-				t = new TimeSignature(token.group, 6)
-				cursor.posGlyph(t)
-				drawing.add(t)
+				// Numeric time signature: stack numerator (top) and denominator (bottom)
+				// Both glyphs share the same x position — they are vertically stacked.
+				const numerator   = new TimeSignature(token.group, 6)   // upper staff half
+				const denominator = new TimeSignature(token.beat,  2)   // lower staff half
 
-				t = new TimeSignature(token.beat, 2)
-				cursor.posGlyph(t)
-				drawing.add(t)
+				cursor.posGlyph(numerator)
+				cursor.posGlyph(denominator)  // same x — intentionally stacked
+				drawing.add(numerator)
+				drawing.add(denominator)
 
-				cursor.incStaveX(t.width + spacerWidth() * 2)
+				cursor.incStaveX(numerator.width + spacerWidth() * 2)
 			}
 
 			break
@@ -417,24 +444,28 @@ function handleToken(token, tokenIndex, staveIndex, cursor) {
 			drawing.add(text)
 			break
 		case 'PerformanceStyle':
-			var pos = token.position !== undefined ? token.position : -11
-			var text = new Text(token.text, pos)
+			// Fixed position: always above the top staff line to avoid colliding with lyrics
+			var text = new Text(token.text, -13, {
+				font: "italic 11px Arial, 'Segoe UI', sans-serif",
+			})
 			cursor.posGlyph(text)
 			drawing.add(text)
 			break
 		case 'Tempo':
-			var pos = token.position !== undefined ? token.position : -15
+			// Fixed position: above the staff, slightly offset right of the barline
 			var text = new Text(
-				// `${token.note} = ${token.duration}`
 				`(${token.duration})`,
-				pos
+				-15,
+				{ font: "11px Arial, 'Segoe UI', sans-serif" }
 			)
 			cursor.posGlyph(text)
 			drawing.add(text)
 			break
 		case 'Dynamic':
-			var pos = token.position !== undefined ? token.position : 7
-			var text = new Text(token.dynamic, pos)
+			// Fixed position: below the bottom staff line
+			var text = new Text(token.dynamic, 9, {
+				font: "italic bold 12px Arial, 'Segoe UI', sans-serif",
+			})
 			cursor.posGlyph(text)
 			drawing.add(text)
 			break

--- a/src/main.js
+++ b/src/main.js
@@ -72,11 +72,11 @@ nwcSamples.forEach((sample) => {
 })
 sample_dom.onchange = function () {
 	const path = samples.includes(sample_dom.value) ? 'samples/' : 'nwcs/'
-	ajax(path + sample_dom.value, processData)
+	ajax(path + sample_dom.value, (buf) => processData(buf, sample_dom.value))
 }
 
 // Default loading
-ajax('samples/WhatChildIsThis.nwc', processData) // samples/jem001.nwc // adohn
+ajax('samples/WhatChildIsThis.nwc', (buf) => processData(buf, 'WhatChildIsThis.nwc'))
 
 // Doesn't work yet
 
@@ -367,6 +367,7 @@ const rerender = () => {
 				const musicContext = new MusicContext(data, window.canvas)
 				interpret(musicContext)
 				score(musicContext)
+				window.__renderComplete = { ts: Date.now(), file: window.__currentFile }
 			},
 			null,
 			(canvas) => {
@@ -380,7 +381,7 @@ const rerender = () => {
 		)
 	} catch (error) {
 		console.error('Rendering failed:', error)
-		alert(`Error rendering score: ${error.message}`)
+		alert(`Error rendering score: ${error.message}\n\nSee DevTools console for the full stack trace.`)
 	}
 }
 
@@ -393,14 +394,19 @@ function setDataAndRender(_data) {
 	rerender()
 }
 
-function processData(payload) {
+function processData(payload, filename) {
 	try {
 		window._lastPayload = payload
+		window.__currentFile = filename || '(unknown)'
+		window.__renderComplete = null
 		var data = decodeNwcArrayBuffer(payload)
 		setDataAndRender(data)
 	} catch (error) {
 		console.error('Failed to process NWC file:', error)
-		alert(`Error loading file: ${error.message}`)
+		// Log the full stack so the root cause is visible in DevTools, then
+		// surface a user-readable message.  We deliberately do NOT catch errors
+		// from rerender() here — those are caught inside rerender() itself.
+		alert(`Error loading file: ${error.message}\n\nSee DevTools console for the full stack trace.`)
 	}
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -16,7 +16,8 @@ import { MusicContext } from './context.js'
 
 window.addEventListener('resize', () => {
 	resizeToFit()
-	quickDraw()
+	var scoreElm = document.getElementById('score')
+	quickDraw(null, -(scoreElm?.scrollLeft || 0), -(scoreElm?.scrollTop || 0))
 })
 
 if (location.hostname === 'localhost') {

--- a/src/nwc.js
+++ b/src/nwc.js
@@ -255,18 +255,21 @@ function adaptObject(obj) {
 
 		case 10: { // Chord (NoteCM)
 			var children = obj.children || []
+			// Filter out any child objects that lack the NoteObj interface (e.g.
+			// misread NoteCMObj children in old binary formats like v1.75).
+			var noteChildren = children.filter(function(c) { return typeof c.getAttributes === 'function' })
 			var notes = []
 			// First child data becomes the primary token properties
-			if (children.length > 0) {
-				var first = children[0]
+			if (noteChildren.length > 0) {
+				var first = noteChildren[0]
 				var firstAttrs = adaptNoteAttrs(first)
 				Object.assign(token, firstAttrs)
 				// Build notes array for all children
-				for (var ci = 0; ci < children.length; ci++) {
-					notes.push(adaptNoteAttrs(children[ci]))
+				for (var ci = 0; ci < noteChildren.length; ci++) {
+					notes.push(adaptNoteAttrs(noteChildren[ci]))
 				}
 			}
-			token.chords = children.length
+			token.chords = noteChildren.length
 			token.notes = notes
 			break
 		}
@@ -314,16 +317,27 @@ function adaptObject(obj) {
 
 		case 18: { // RestChord (RestCM)
 			var rcChildren = obj.children || []
+			// Filter out any child objects that lack the NoteObj interface (e.g.
+			// misread NoteCMObj children in old binary formats like v1.75).
+			var rcNoteChildren = rcChildren.filter(function(c) { return typeof c.getAttributes === 'function' })
 			var rcNotes = []
-			if (rcChildren.length > 0) {
-				var rcFirst = rcChildren[0]
+			if (rcNoteChildren.length > 0) {
+				var rcFirst = rcNoteChildren[0]
 				var rcFirstAttrs = adaptNoteAttrs(rcFirst)
 				Object.assign(token, rcFirstAttrs)
-				for (var ri = 0; ri < rcChildren.length; ri++) {
-					rcNotes.push(adaptNoteAttrs(rcChildren[ri]))
+				for (var ri = 0; ri < rcNoteChildren.length; ri++) {
+					rcNotes.push(adaptNoteAttrs(rcNoteChildren[ri]))
 				}
 			}
-			token.chords = rcChildren.length
+			// Fall back to parent object's own duration data when no valid note children
+			if (rcNoteChildren.length === 0 && typeof obj.getDuration === 'function') {
+				token.duration = ADAPTER_DURATIONS[obj.getDuration()] || 4
+				var rcDt = typeof obj.getDurationType === 'function' ? obj.getDurationType() : 0
+				token.dots = (rcDt & 0x02) ? 2 : (rcDt & 0x01) ? 1 : 0
+				token.position = 0
+				token.triplet = (rcDt >> 2) & 3
+			}
+			token.chords = rcNoteChildren.length
 			token.notes = rcNotes
 			break
 		}


### PR DESCRIPTION
- Virtual viewport rendering — canvas stays viewport-sized; only the visible portion is rendered on each scroll frame, eliminating canvas size overflow errors on large scores
- Transform-based zoom — new zoom slider applies ctx.scale() in real time (no re-layout); Size +/- buttons retained for engraving quality changes that require full re-layout
- Triplet rest fix — RestObj.getDurationType() was missing triplet bit extraction from data2[1], causing barlines to drift across staves (e.g. bachjesu.nwc)
- Double-dot duration fix — the dot loop produced 9/4 instead of the correct 7/4 for double-dotted notes
- Defensive guards — NaN/Infinity protection in Fraction.gcd(), layout loop iteration cap, invalid duration fallbacks, font size clamping, and Chord/RestChord child filtering for old binary formats
- Bumping to v2.0.0